### PR TITLE
Fix for Illegal Argument Exception in AFK checker caused by distance …

### DIFF
--- a/TreeboTickets/pom.xml
+++ b/TreeboTickets/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>me.ShakeforProtein</groupId>
     <artifactId>TreeboTickets</artifactId>
-    <version>2.0.5</version>
+    <version>2.0.6</version>
     <packaging>jar</packaging>
 
     <name>TreeboTickets</name>

--- a/TreeboTickets/src/main/java/me/shakeforprotein/treebotickets/TreeboTickets.java
+++ b/TreeboTickets/src/main/java/me/shakeforprotein/treebotickets/TreeboTickets.java
@@ -140,7 +140,7 @@ public final class TreeboTickets extends JavaPlugin {
                 for(PlayerOntimeObject playerOntimeObject : playerOntimeHash.values()){
                     if(playerOntimeObject.getPlayer().isOnline()){
                         if(playerOntimeObject.isAFK()){
-                            if(playerOntimeObject.getLastLocation().distance(playerOntimeObject.getPlayer().getLocation()) > 10){
+                            if(playerOntimeObject.getLastLocation().getWorld() == playerOntimeObject.getPlayer().getLocation().getWorld() && playerOntimeObject.getLastLocation().distance(playerOntimeObject.getPlayer().getLocation()) > 10){
                                 playerOntimeObject.setAFK(false);
                             } else {
                                 playerOntimeObject.setAfkTime(playerOntimeObject.getAfkTime() + 1200);


### PR DESCRIPTION
Fix for Illegal Argument Exception in AFK checker caused by distance check after world change.